### PR TITLE
OnMove200

### DIFF
--- a/src/device/OnMove200.cc
+++ b/src/device/OnMove200.cc
@@ -235,27 +235,129 @@ namespace device
   }
 
   void OnMove200::parseOMDFile(const unsigned char* bytes, int length, Session *session)
-  {
+    {
     const unsigned char* chunk;
-    int numPoints = 0;
-    time_t startTime = session->getTime();
+         	
+	uint32_t totalPoint = 0;
+	for(int i=0;i<length;i=i+30) 
+    { 
+    chunk = &bytes[i]; 
+    totalPoint++;
+	}
+	  
+	uint32_t nPoints = 0;
+    uint32_t startPoint = 1 ; 
+    uint32_t endPoint = 0; 
+    uint32_t restTime = 0; 
+    uint32_t restDistance = 0; 
+                        
+    DEBUG_CMD(int lapIndex = 0); 
+ 
+    for(int i=0;i<length;i=i+20) 
+    { 
+    chunk = &bytes[i]; 
+                               
+    nPoints++; 
+    if(nPoints % 3 == 0) continue ; 
+        
+    endPoint++;
+                
+    uint32_t time = bytesToInt2(chunk[12],chunk[13]); 
+    uint32_t time2 = bytesToInt2(chunk[32],chunk[33]); 
+    uint32_t time3 = bytesToInt2(chunk[52],chunk[53]); 
+    uint32_t distance = bytesToInt4(chunk[8], chunk[9], chunk[10], chunk[11]); 
+                  
+    if((time == time2)||(time == time3))
+	{
+    uint32_t totalTime = time - restTime ; 
+    uint32_t totalDistance = distance - restDistance ; 
+ 
+	if((startPoint == endPoint)||(distance = 0)) continue;
+ 
+    double averageSpeed = totalDistance * 3.6 / totalTime ; 
+ 
+    //DEBUG_CMD(std::cout << "Lap " << lapIndex++ << std::endl); 
+    Lap *l = new Lap(startPoint, endPoint, totalTime, totalDistance, 0, averageSpeed, 0, 0, 0, 0, 0, 0); 
+    session->addLap(l); 
+      
+    //lapCount++;
+    startPoint = endPoint ; 
+    restTime = time ; 
+    restDistance = distance ;     
+	}  
+		
+	else if (endPoint == totalPoint)
+	{
+	uint32_t totalTime = time - restTime ; 
+    uint32_t totalDistance = distance - restDistance ; 
+       
+    double averageSpeed = totalDistance * 3.6 / totalTime ; 
+ 
+    DEBUG_CMD(std::cout << "Lap " << lapIndex++ << std::endl); 
+    Lap *l = new Lap(startPoint, endPoint, totalTime, totalDistance, 0, averageSpeed, 0, 0, 0, 0, 0, 0); 
+    session->addLap(l); 
+    }
+	}
+
+	//Recherche des points
+	uint32_t numPoints = 0;
+	uint32_t aPoints = 0;
+    time_t startTime = session->getTime(); 
+    std::list<Lap*>::iterator lap = session->getLaps().begin();
+    
     for(int i = 0; i < length; i += 20)
     {
       numPoints++;
-      // Every other 3 line doesn't contain coordinates
-      if(numPoints % 3 == 0) continue;
+      if(numPoints % 3 == 0) continue ;
       chunk = &bytes[i];
+      if((numPoints % 3 == 1)||(numPoints == 1))
+      {
       double latitude = ((double) bytesToInt4(chunk[0], chunk[1], chunk[2], chunk[3])) / 1000000.;
       double longitude = ((double) bytesToInt4(chunk[4], chunk[5], chunk[6], chunk[7])) / 1000000.;
-      // Not sure if distance is really on 4 bytes or only on 2, but 2 would seem limited (65 km, can be short for a bike session)
       uint32_t distance = bytesToInt4(chunk[8], chunk[9], chunk[10], chunk[11]);
       uint32_t time = bytesToInt2(chunk[12], chunk[13]);
-      // Heart rate for points of lines n and n+1 are on line n+2 (the every other 3 line that doesn't contain coordinates)
+      double speed = ((double)bytesToInt2(chunk[42],chunk[43]));
       uint32_t hr = chunk[46];
-      if(numPoints % 3 == 2) hr = chunk[36];
-      Point *p = new Point(latitude, longitude, FieldUndef, FieldUndef, startTime + time, 0, hr, 3);
+      
+      Point *p = new Point(latitude, longitude, 0, speed, startTime + time, 0, hr, 3);
       p->setDistance(distance);
       session->addPoint(p);
+      aPoints++;
+      }
+      else if((numPoints % 3 == 2)||(numPoints == 2))
+      {
+      double latitude = ((double) bytesToInt4(chunk[0], chunk[1], chunk[2], chunk[3])) / 1000000.;
+      double longitude = ((double) bytesToInt4(chunk[4], chunk[5], chunk[6], chunk[7])) / 1000000.;
+      uint32_t distance = bytesToInt4(chunk[8], chunk[9], chunk[10], chunk[11]);
+      uint32_t time = bytesToInt2(chunk[12], chunk[13]);
+      double speed = ((double)bytesToInt2(chunk[32],chunk[33]));
+      uint32_t hr = chunk[36];
+      
+      Point *p = new Point(latitude, longitude, 0, speed, startTime + time, 0, hr, 3);
+      p->setDistance(distance);
+      session->addPoint(p);
+      aPoints++;
+      }
+        
+   			if(lap != session->getLaps().end() && aPoints == (*lap)->getFirstPointId())
+			{
+				(*lap)->setStartPoint(session->getPoints().back());
+			}
+			while(lap != session->getLaps().end() && aPoints >= (*lap)->getLastPointId())
+			{
+				// This if is a safe net but should never be used (unless laps are not in order or first lap doesn't start at 0 or ...)
+				if((*lap)->getStartPoint() == NULL)
+				{
+					std::cerr << "Error: lap has no start point and yet I want to go to the next lap ! (lap: " << (*lap)->getFirstPointId() << " - " << (*lap)->getLastPointId() << ")" << std::endl;
+					(*lap)->setStartPoint(session->getPoints().back());
+				}
+				(*lap)->setEndPoint(session->getPoints().back());
+				++lap;
+				if(lap != session->getLaps().end())
+				{
+					(*lap)->setStartPoint(session->getPoints().back());
+				}
+			}
     }
   }
 }


### PR DESCRIPTION

[13c858931203bde0d40c.gpx.txt](https://github.com/ColinPitrat/kalenji-gps-watch-reader/files/462672/13c858931203bde0d40c.gpx.txt)
[ACT_0010.OMD.txt](https://github.com/ColinPitrat/kalenji-gps-watch-reader/files/462674/ACT_0010.OMD.txt)
[ACT_0010.OMH.txt](https://github.com/ColinPitrat/kalenji-gps-watch-reader/files/462673/ACT_0010.OMH.txt)
[13c858931203bde0d40c.xls.txt](https://github.com/ColinPitrat/kalenji-gps-watch-reader/files/462675/13c858931203bde0d40c.xls.txt)
[20160908_125500.gpx.txt](https://github.com/ColinPitrat/kalenji-gps-watch-reader/files/462676/20160908_125500.gpx.txt)




Bonsoir Colin,
J'ai testé la version suivante sur ma séance d'aujourd'hui, et j'ai réussi à la récupérer sur l'application de Decathlon.
J'ai encore un point complètement loupé en fin de session, et il me génère un dernier lap complètement faux. Decathlon le supprime aussi de son gpx et de ses laps.
Pour le reste, en éditant le gpx et en le testant sur pytrainer, le temps, la distance et la vitesse moyenne des laps sont bons. Les coordonnées des laps sont par contre fausses, je pense qu'un décalage se créé quelque part entre l'identification du point de départ et d'arrivée du lap, qui sont bien identifiés, et le recensement des coordonées des laps, qui se retrouve décalée pour une raison qu'il faut que je trouve.

J'essaierai de m'y remettre ce week-end, en tout cas, les laps décryptés par kalenji correspondent bien aux laps décryptés par le programme,
Je poste les fichiers de ma session,
Bonne soirée,

Thomas