### PR TITLE
fix some "used uninitialized" warnings

### DIFF
--- a/src/bom/Field.h
+++ b/src/bom/Field.h
@@ -17,7 +17,7 @@ class Field
 		Field(T value) : _defined(true), _value(value) {};
 
 		// Constructor of an invalid field, using the constant defined above.
-		Field(TFieldUndef unused) : _defined(false) {};
+		Field(TFieldUndef unused) : _defined(false), _value(T()) {};
 
 		bool isDefined() const { return _defined; };
 		const T& getValue() const { return _value; };

--- a/src/device/OnMove200.cc
+++ b/src/device/OnMove200.cc
@@ -217,12 +217,12 @@ namespace device
     //uint32_t fileNum = static_cast<uint32_t>(bytes[19]);
 
     tm time;
+    memset(&time, 0, sizeof(time));
     time.tm_year  = 100 + year;// In tm, year is year since 1900. GPS returns year since 2000
     time.tm_mon   = month - 1;// In tm, month is between 0 and 11.
     time.tm_mday  = day;
     time.tm_hour  = hour;
     time.tm_min   = minute;
-    time.tm_sec   = 0;
     time.tm_isdst = -1;
     session->setTime(time);
     session->setDistance(distance);


### PR DESCRIPTION
g++ version 8.1.1 bails about some tm fileds not being intialized.
Fix the above explicitly memsetting the 'time' struct before the
first usage, as already done elsewhere.

The Field class does not initialize the _value field with the
'Unused' constructor: explicitly call the default one on such field.